### PR TITLE
Correción ec.(86-87-98-99)

### DIFF
--- a/app-termo-rel.tex
+++ b/app-termo-rel.tex
@@ -353,12 +353,12 @@ obtenemos una ecuaci'on de estado politr'opica \eqref{estadopolitropica} con 'in
 \begin{enumerate}
 \item \emph{Electrones no relativistas} ($p_F\ll m_{e}c$). Equivale por  \eqref{xrelativo_electrones} a que las densidades t'ipicas de las enanas blancas sean bajas, del orden de $\rho_0\ll10^{9}\,[kg/m^3]$. Reemplazando dicho $x_F$ en la expansi'on asint'otica de la presi'on \eqref{presionfermi1-asintotico}, tenemos:
 \begin{equation}\label{fermi_norelativista}
- \boxed{P_e=\frac{3^{2/3}\pi^{4/3}}{20}\frac{\hbar^2}{m_e(m_u\mu_e)^{5/3}}\rho_0^{5/3}\approx1.00359\cdot 10^{7}\,\left(\frac{\rho_0}{\mu_e}\right)^{5/3}\,MKS.}
+ \boxed{P_e=\frac{3^{2/3}\pi^{4/3}}{5}\frac{\hbar^2}{m_e(m_u\mu_e)^{5/3}}\rho_0^{5/3}\approx1.00359\cdot 10^{7}\,\left(\frac{\rho_0}{\mu_e}\right)^{5/3}\,MKS.}
 \end{equation}
 
 \item \emph{Neutrones no relativistas} ($p_F\ll m_{n}c$). Equivale por  \eqref{xrelativo_neutrones} a que las densidades t'ipicas de las estrellas de neutrones sean bajas, del orden de $\rho\ll6\cdot10^{18}\,[kg/m^3]$.  Reemplazando dicho $x_F$ en la expansi'on asint'otica de la presi'on \eqref{presionfermi1-asintotico}, tenemos:
 \begin{equation}\label{fermi_norelativista2}
- \boxed{P_n=\frac{3^{2/3}\pi^{4/3}}{20}\frac{\hbar^2}{m_n^{8/3}}\rho_0^{5/3}\approx5.3803\cdot 10^{3}\,\left(\rho_0\right)^{5/3}\,MKS.}
+ \boxed{P_n=\frac{3^{2/3}\pi^{4/3}}{5}\frac{\hbar^2}{m_n^{8/3}}\rho_0^{5/3}\approx5.3803\cdot 10^{3}\,\left(\rho_0\right)^{5/3}\,MKS.}
 \end{equation}
 
 \end{enumerate}
@@ -390,12 +390,12 @@ obtenemos una ecuaci'on de estado politr'opica \eqref{estadopolitropica} con 'in
 \begin{enumerate}
 \item \emph{Electrones ultra-relativistas} ($p_F\gg m_{e}c$). Equivale por  \eqref{xrelativo_electrones} a que las densidades t'ipicas de las enanas blancas sean altas, del orden de $\rho_0\gg10^{9}\,[kg/m^3]$. Reemplazando dicho $x_F$ en la expansi'on asint'otica de la presi'on \eqref{presionfermi2-asintotico}, tenemos:
 \begin{equation}\label{fermi_relativista}
- \boxed{P_e=\frac{3^{1/3}\pi^{2/3}}{8}\frac{\hbar c}{(m_u\mu_e)^{4/3}}\rho_0^{4/3}\approx1.2435\cdot 10^{10}\,\left(\frac{\rho_0}{\mu_e}\right)^{4/3}\,MKS.}
+ \boxed{P_e=\frac{3^{1/3}\pi^{2/3}}{4}\frac{\hbar c}{(m_u\mu_e)^{4/3}}\rho_0^{4/3}\approx1.2435\cdot 10^{10}\,\left(\frac{\rho_0}{\mu_e}\right)^{4/3}\,MKS.}
 \end{equation}
 
 \item \emph{Neutrones ultra-relativistas} ($p_F\gg m_{n}c$). Equivale por  \eqref{xrelativo_neutrones} a que las densidades t'ipicas de las estrellas de neutrones sean altas, del orden de $\rho_0\gg6\cdot10^{18}\,[kg/m^3]$.Reemplazando dicho $x_F$ en la expansi'on asint'otica de la presi'on \eqref{presionfermi2-asintotico}, tenemos:
 \begin{equation}\label{fermi_relativista2}
- \boxed{P_n=\frac{3^{1/3}\pi^{2/3}}{8}\frac{\hbar c}{m_n^{4/3}}\rho_0^{4/3}\approx1.2293\cdot 10^{10}\,\left(\rho_0\right)^{4/3}\,MKS.}
+ \boxed{P_n=\frac{3^{1/3}\pi^{2/3}}{4}\frac{\hbar c}{m_n^{4/3}}\rho_0^{4/3}\approx1.2293\cdot 10^{10}\,\left(\rho_0\right)^{4/3}\,MKS.}
 \end{equation}
 
 \end{enumerate}

--- a/app-termo-rel.tex
+++ b/app-termo-rel.tex
@@ -353,12 +353,12 @@ obtenemos una ecuaci'on de estado politr'opica \eqref{estadopolitropica} con 'in
 \begin{enumerate}
 \item \emph{Electrones no relativistas} ($p_F\ll m_{e}c$). Equivale por  \eqref{xrelativo_electrones} a que las densidades t'ipicas de las enanas blancas sean bajas, del orden de $\rho_0\ll10^{9}\,[kg/m^3]$. Reemplazando dicho $x_F$ en la expansi'on asint'otica de la presi'on \eqref{presionfermi1-asintotico}, tenemos:
 \begin{equation}\label{fermi_norelativista}
- \boxed{P_e=\frac{3^{2/3}\pi^{4/3}}{5}\frac{\hbar^2}{m_e(m_u\mu_e)^{5/3}}\rho_0^{5/3}\approx1.00359\cdot 10^{7}\,\left(\frac{\rho_0}{\mu_e}\right)^{5/3}\,MKS.}
+ \boxed{P_e=\frac{3^{2/3}\pi^{4/3}}{20}\frac{\hbar^2}{m_e(m_u\mu_e)^{5/3}}\rho_0^{5/3}\approx1.00359\cdot 10^{7}\,\left(\frac{\rho_0}{\mu_e}\right)^{5/3}\,MKS.}
 \end{equation}
 
 \item \emph{Neutrones no relativistas} ($p_F\ll m_{n}c$). Equivale por  \eqref{xrelativo_neutrones} a que las densidades t'ipicas de las estrellas de neutrones sean bajas, del orden de $\rho\ll6\cdot10^{18}\,[kg/m^3]$.  Reemplazando dicho $x_F$ en la expansi'on asint'otica de la presi'on \eqref{presionfermi1-asintotico}, tenemos:
 \begin{equation}\label{fermi_norelativista2}
- \boxed{P_n=\frac{3^{2/3}\pi^{4/3}}{5}\frac{\hbar^2}{m_n^{8/3}}\rho_0^{5/3}\approx5.3803\cdot 10^{3}\,\left(\rho_0\right)^{5/3}\,MKS.}
+ \boxed{P_n=\frac{3^{2/3}\pi^{4/3}}{20}\frac{\hbar^2}{m_n^{8/3}}\rho_0^{5/3}\approx5.3803\cdot 10^{3}\,\left(\rho_0\right)^{5/3}\,MKS.}
 \end{equation}
 
 \end{enumerate}
@@ -390,12 +390,12 @@ obtenemos una ecuaci'on de estado politr'opica \eqref{estadopolitropica} con 'in
 \begin{enumerate}
 \item \emph{Electrones ultra-relativistas} ($p_F\gg m_{e}c$). Equivale por  \eqref{xrelativo_electrones} a que las densidades t'ipicas de las enanas blancas sean altas, del orden de $\rho_0\gg10^{9}\,[kg/m^3]$. Reemplazando dicho $x_F$ en la expansi'on asint'otica de la presi'on \eqref{presionfermi2-asintotico}, tenemos:
 \begin{equation}\label{fermi_relativista}
- \boxed{P_e=\frac{3^{1/3}\pi^{2/3}}{4}\frac{\hbar c}{(m_u\mu_e)^{4/3}}\rho_0^{4/3}\approx1.2435\cdot 10^{10}\,\left(\frac{\rho_0}{\mu_e}\right)^{4/3}\,MKS.}
+ \boxed{P_e=\frac{3^{1/3}\pi^{2/3}}{8}\frac{\hbar c}{(m_u\mu_e)^{4/3}}\rho_0^{4/3}\approx1.2435\cdot 10^{10}\,\left(\frac{\rho_0}{\mu_e}\right)^{4/3}\,MKS.}
 \end{equation}
 
 \item \emph{Neutrones ultra-relativistas} ($p_F\gg m_{n}c$). Equivale por  \eqref{xrelativo_neutrones} a que las densidades t'ipicas de las estrellas de neutrones sean altas, del orden de $\rho_0\gg6\cdot10^{18}\,[kg/m^3]$.Reemplazando dicho $x_F$ en la expansi'on asint'otica de la presi'on \eqref{presionfermi2-asintotico}, tenemos:
 \begin{equation}\label{fermi_relativista2}
- \boxed{P_e=\frac{3^{1/3}\pi^{2/3}}{4}\frac{\hbar c}{m_n^{4/3}}\rho_0^{4/3}\approx1.2293\cdot 10^{10}\,\left(\rho_0\right)^{4/3}\,MKS.}
+ \boxed{P_n=\frac{3^{1/3}\pi^{2/3}}{8}\frac{\hbar c}{m_n^{4/3}}\rho_0^{4/3}\approx1.2293\cdot 10^{10}\,\left(\rho_0\right)^{4/3}\,MKS.}
 \end{equation}
 
 \end{enumerate}


### PR DESCRIPTION
En las ec.s (86-87-98-99)) hubo un error al simplificar, pues
 
$8*(\frac{1}{8})^{5/3} = 2^3 * (2^3)^{-5/3) = 2^2 = 4$ ec.(86-87)
$8*(\frac{1}{8})^{4/3} = 2^3 * (2^3)^{-4/3) = 2^{-1} = 1/2 $ ec.(86-87)

Ademas en la ec. (99) escribió P_e en vez de P_n.
Saludos