### PR TITLE
typo Ec. (2.81) corregido

### DIFF
--- a/cap-tensores-y-geometria-diferencial.tex
+++ b/cap-tensores-y-geometria-diferencial.tex
@@ -909,7 +909,7 @@ De aqu'i, tenemos que
 \end{equation}
 De esta forma, encontramos que
 \begin{equation}
-\frac{\delta L}{\delta x^i }=\frac{1}{2\tilde{L}}(\partial_k g_{ij})\dot{x}^i\dot{x}^j+\frac{\dot{\tilde{L}}}{\tilde{L}^2}g_{kj}\dot{x}^j-\frac{1}{\tilde{L}}(\partial_l g_{kj})\dot{x}^j\dot{x}^l-\frac{1}{\tilde{L}}g_{kj}\ddot{x}^j.
+\frac{\delta L}{\delta x^k }=\frac{1}{2\tilde{L}}(\partial_k g_{ij})\dot{x}^i\dot{x}^j+\frac{\dot{\tilde{L}}}{\tilde{L}^2}g_{kj}\dot{x}^j-\frac{1}{\tilde{L}}(\partial_l g_{kj})\dot{x}^j\dot{x}^l-\frac{1}{\tilde{L}}g_{kj}\ddot{x}^j.
 \end{equation}
 Multiplicando por $\tilde{L}g^{ki}$ y reordenando t'erminos obtenemos
 \begin{align}


### PR DESCRIPTION
El lado izquierdo de (2.81) tenía índice libre _i_ cuando en el lado derecho era _k_. 

Corregido el lado izquierdo para concordar con el derecho.